### PR TITLE
FAN SPEED 'New Features'

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7435,6 +7435,11 @@ inline void gcode_M105() {
    * M106: Set Fan Speed
    *
    *  S<int>   Speed between 0-255
+   *  T<int>   Temporary Speed :
+   *           1=return to old ; 
+   *           2=Apply memorised Fanspeed
+   *           3-255= memorise Fanspeed 
+   *           Require T2 before T1 to memorise current speed
    *  P<index> Fan index, if more than one fan
    */
   inline void gcode_M106() {


### PR DESCRIPTION
:white_check_mark:**FAN SPEED 'New Features'**

> Now you can use your own fan speed during a print and recover the original speed
> Usefull when needed to go on parking with a special fan speed value or anything need a special blowing property


M106 - Fan on: S0-255 : T3-255 / T2 / T1 Temporary set speed during printing
T1 return to previous / T2 apply extra speed / T3-255 set without applying
