### PR TITLE
M106 FAN SPEED 'New Features

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -355,6 +355,8 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
 
 #if FAN_COUNT > 0
   extern int16_t fanSpeeds[FAN_COUNT];
+  extern int16_t old_fanSpeeds[FAN_COUNT];
+  extern int16_t new_fanSpeeds[FAN_COUNT];
   #if ENABLED(PROBING_FANS_OFF)
     extern bool fans_paused;
     extern int16_t paused_fanSpeeds[FAN_COUNT];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7444,9 +7444,16 @@ inline void gcode_M105() {
    */
   inline void gcode_M106() {
     uint16_t s = parser.ushortval('S', 255);
-    NOMORE(s, 255);
     const uint8_t p = parser.byteval('P', 0);
-    if (p < FAN_COUNT) fanSpeeds[p] = s;
+    if (p < FAN_COUNT)
+      if(t>0){
+        if (t>2){NOMORE(t, 255);new_fanSpeeds[p]=t; }
+        else if (t<2){fanSpeeds[p] = old_fanSpeeds[p];}
+             else  {old_fanSpeeds[p] = fanSpeeds[p]; fanSpeeds[p] = new_fanSpeeds[p];}
+       return ;
+    }
+      NOMORE(s, 255);
+      fanSpeeds[p] = s;
   }
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -465,6 +465,9 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
 
 #if FAN_COUNT > 0
   int16_t fanSpeeds[FAN_COUNT] = { 0 };
+  int16_t old_fanSpeeds[FAN_COUNT];
+  int16_t new_fanSpeeds[FAN_COUNT];
+
   #if ENABLED(PROBING_FANS_OFF)
     bool fans_paused = false;
     int16_t paused_fanSpeeds[FAN_COUNT] = { 0 };


### PR DESCRIPTION
:white_check_mark:**FAN SPEED 'New Features'**

> Now you can use your own fan speed during a print and recover the original speed
> Usefull when needed to go on parking with a special fan speed value or anything need a special blowing property


M106 - Fan on: S0-255 : T3-255 / T2 / T1 Temporary set speed during printing
T1 return to previous / T2 apply extra speed / T3-255 set without applying
